### PR TITLE
Use the correct branch for the xarm_ros2 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "xarm_ros2"]
 	path = xarm_ros2
 	url = https://github.com/xArm-Developer/xarm_ros2
+    branch = humble
 [submodule "realsense-ros"]
 	path = realsense-ros
 	url = git@github.com:IntelRealSense/realsense-ros.git


### PR DESCRIPTION
The configured branch for the xarm_ros2 submodule was wrong, making `colcon build` fail. This PR fixes it.